### PR TITLE
Fix intent-filter for bilibili://search deep link

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -99,13 +99,6 @@
             </intent-filter>
             <intent-filter android:label="PiliPlus">
                 <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="bilibili" />
-                <data android:host="search" />
-            </intent-filter>
-            <intent-filter android:label="PiliPlus">
-                <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.SEARCH" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -118,9 +111,10 @@
                     android:pathPattern="/readlist" />
                 <data android:host="advertise" android:path="/home" />
                 <data android:host="clip" />
-                <data android:host="search" />
+                <data android:host="search" android:pathPattern=".*" />
                 <data android:host="stardust-search" />
                 <data android:host="music" />
+                <data android:host="cheese" />
                 <data android:host="bangumi"
                     android:pathPattern="/season.*" />
                 <data android:host="bangumi" android:pathPattern="/.*" />
@@ -165,7 +159,6 @@
                 <data android:host="user_center" android:path="/vip" />
                 <data android:host="history" />
                 <data android:host="charge" android:path="/rank" />
-                <data android:host="assistant" />
                 <data android:host="assistant" />
                 <data android:host="feedback" />
                 <data android:host="auth" android:path="/launch" />

--- a/lib/utils/app_scheme.dart
+++ b/lib/utils/app_scheme.dart
@@ -219,7 +219,8 @@ class PiliScheme {
               );
               return true;
             }
-            return false;
+            Get.toNamed('search');
+            return true;
           case 'article':
             // bilibili://article/40679479?jump_opus=1&jump_opus_type=1&opus_type=article&h5awaken=random
             String? id = uriDigitRegExp.firstMatch(path)?.group(1);


### PR DESCRIPTION
## Fix intent-filter for bilibili://search deep link

This PR adds a proper `<intent-filter>` to handle `bilibili://search?keyword=...` deep links.

### Problem
In the current version, when running the following command:

```bash
am start "bilibili://search?keyword=abc" com.example.piliplus
```
the app does not appear in the system chooser dialog.
<p align="center">
  <img src="https://github.com/user-attachments/assets/7406fd48-c529-4634-a436-642e939974b2" alt="S50804-08165698_android" width="300" />
</p>
