### PR TITLE
feat: 优化折叠屏和小尺寸平板的视频体验

### DIFF
--- a/lib/pages/video/reply/widgets/reply_item_grpc.dart
+++ b/lib/pages/video/reply/widgets/reply_item_grpc.dart
@@ -186,160 +186,171 @@ class ReplyItemGrpc extends StatelessWidget {
   );
 
   Widget content(BuildContext context, ThemeData theme) {
-    final padding = EdgeInsets.only(
-      left: replyLevel == 0 ? 6 : 45,
-      right: 6,
-    );
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: () {
-            feedBack();
-            Get.toNamed('/member?mid=${replyItem.mid}');
-          },
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            spacing: 12,
-            children: [
-              _buildAvatar(),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final conciseMode = constraints.maxWidth <= 320;
+        final padding = EdgeInsets.only(
+          left: replyLevel == 0 ? 6 : (conciseMode ? 6 : 45),
+          right: 6,
+        );
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () {
+                feedBack();
+                Get.toNamed('/member?mid=${replyItem.mid}');
+              },
+              child: Row(
                 mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                spacing: 12,
                 children: [
-                  Row(
+                  _buildAvatar(),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
-                    spacing: 6,
                     children: [
-                      Text(
-                        replyItem.member.name,
-                        style: TextStyle(
-                          color:
-                              (replyItem.member.vipStatus > 0 &&
-                                  replyItem.member.vipType == 2)
-                              ? theme.colorScheme.vipColor
-                              : theme.colorScheme.outline,
-                          fontSize: 13,
-                        ),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        spacing: 6,
+                        children: [
+                          Text(
+                            replyItem.member.name,
+                            style: TextStyle(
+                              color:
+                                  (replyItem.member.vipStatus > 0 &&
+                                      replyItem.member.vipType == 2)
+                                  ? theme.colorScheme.vipColor
+                                  : theme.colorScheme.outline,
+                              fontSize: 13,
+                            ),
+                          ),
+                          Image.asset(
+                            'assets/images/lv/lv${replyItem.member.isSeniorMember == 1 ? '6_s' : replyItem.member.level}.png',
+                            height: 11,
+                          ),
+                          if (replyItem.mid == upMid)
+                            const PBadge(
+                              text: 'UP',
+                              size: PBadgeSize.small,
+                              isStack: false,
+                              fontSize: 9,
+                            ),
+                        ],
                       ),
-                      Image.asset(
-                        'assets/images/lv/lv${replyItem.member.isSeniorMember == 1 ? '6_s' : replyItem.member.level}.png',
-                        height: 11,
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[
+                          Text(
+                            replyLevel == 0
+                                ? DateFormatUtils.format(
+                                    replyItem.ctime.toInt(),
+                                    format: DateFormatUtils.longFormatDs,
+                                  )
+                                : DateFormatUtils.dateFormat(
+                                    replyItem.ctime.toInt(),
+                                  ),
+                            style: TextStyle(
+                              fontSize: theme.textTheme.labelSmall!.fontSize,
+                              color: theme.colorScheme.outline,
+                            ),
+                          ),
+                          if (replyItem.replyControl.hasLocation())
+                            Text(
+                              ' • ${replyItem.replyControl.location}',
+                              style: TextStyle(
+                                fontSize: theme.textTheme.labelSmall!.fontSize,
+                                color: theme.colorScheme.outline,
+                              ),
+                            ),
+                        ],
                       ),
-                      if (replyItem.mid == upMid)
-                        const PBadge(
-                          text: 'UP',
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 10),
+            Padding(
+              padding: padding,
+              child: custom_text.Text.rich(
+                primary: theme.colorScheme.primary,
+                style: TextStyle(
+                  height: 1.75,
+                  fontSize: theme.textTheme.bodyMedium!.fontSize,
+                ),
+                maxLines: replyLevel == 1 ? replyLengthLimit : null,
+                TextSpan(
+                  children: [
+                    if (replyItem.replyControl.isUpTop) ...[
+                      const WidgetSpan(
+                        alignment: PlaceholderAlignment.middle,
+                        child: PBadge(
+                          text: 'TOP',
                           size: PBadgeSize.small,
                           isStack: false,
+                          type: PBadgeType.line_primary,
                           fontSize: 9,
-                        ),
-                    ],
-                  ),
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      Text(
-                        replyLevel == 0
-                            ? DateFormatUtils.format(
-                                replyItem.ctime.toInt(),
-                                format: DateFormatUtils.longFormatDs,
-                              )
-                            : DateFormatUtils.dateFormat(
-                                replyItem.ctime.toInt(),
-                              ),
-                        style: TextStyle(
-                          fontSize: theme.textTheme.labelSmall!.fontSize,
-                          color: theme.colorScheme.outline,
+                          textScaleFactor: 1,
                         ),
                       ),
-                      if (replyItem.replyControl.hasLocation())
-                        Text(
-                          ' • ${replyItem.replyControl.location}',
-                          style: TextStyle(
-                            fontSize: theme.textTheme.labelSmall!.fontSize,
-                            color: theme.colorScheme.outline,
-                          ),
-                        ),
+                      const TextSpan(text: ' '),
                     ],
+                    buildContent(context, theme, replyItem),
+                  ],
+                ),
+              ),
+            ),
+            if (replyItem.content.pictures.isNotEmpty) ...[
+              Padding(
+                padding: padding,
+                child: LayoutBuilder(
+                  builder: (context, constraints) => CustomGridView(
+                    maxWidth: constraints.maxWidth,
+                    picArr: replyItem.content.pictures
+                        .map(
+                          (item) => ImageModel(
+                            width: item.imgWidth,
+                            height: item.imgHeight,
+                            url: item.imgSrc,
+                          ),
+                        )
+                        .toList(),
+                    onViewImage: onViewImage,
+                    onDismissed: onDismissed,
                   ),
-                ],
+                ),
+              ),
+              const SizedBox(height: 4),
+            ],
+            if (replyLevel != 0) ...[
+              const SizedBox(height: 4),
+              buttonAction(context, theme, conciseMode, replyItem.replyControl),
+            ],
+            if (replyLevel == 1 && replyItem.count > Int64.ZERO) ...[
+              Padding(
+                padding: const EdgeInsets.only(top: 5, bottom: 12),
+                child: replyItemRow(
+                  context,
+                  theme,
+                  conciseMode,
+                  replyItem.replies,
+                ),
               ),
             ],
-          ),
-        ),
-        const SizedBox(height: 10),
-        Padding(
-          padding: padding,
-          child: custom_text.Text.rich(
-            primary: theme.colorScheme.primary,
-            style: TextStyle(
-              height: 1.75,
-              fontSize: theme.textTheme.bodyMedium!.fontSize,
-            ),
-            maxLines: replyLevel == 1 ? replyLengthLimit : null,
-            TextSpan(
-              children: [
-                if (replyItem.replyControl.isUpTop) ...[
-                  const WidgetSpan(
-                    alignment: PlaceholderAlignment.middle,
-                    child: PBadge(
-                      text: 'TOP',
-                      size: PBadgeSize.small,
-                      isStack: false,
-                      type: PBadgeType.line_primary,
-                      fontSize: 9,
-                      textScaleFactor: 1,
-                    ),
-                  ),
-                  const TextSpan(text: ' '),
-                ],
-                buildContent(context, theme, replyItem),
-              ],
-            ),
-          ),
-        ),
-        if (replyItem.content.pictures.isNotEmpty) ...[
-          Padding(
-            padding: padding,
-            child: LayoutBuilder(
-              builder: (context, constraints) => CustomGridView(
-                maxWidth: constraints.maxWidth,
-                picArr: replyItem.content.pictures
-                    .map(
-                      (item) => ImageModel(
-                        width: item.imgWidth,
-                        height: item.imgHeight,
-                        url: item.imgSrc,
-                      ),
-                    )
-                    .toList(),
-                onViewImage: onViewImage,
-                onDismissed: onDismissed,
-              ),
-            ),
-          ),
-          const SizedBox(height: 4),
-        ],
-        if (replyLevel != 0) ...[
-          const SizedBox(height: 4),
-          buttonAction(context, theme, replyItem.replyControl),
-        ],
-        if (replyLevel == 1 && replyItem.count > Int64.ZERO) ...[
-          Padding(
-            padding: const EdgeInsets.only(top: 5, bottom: 12),
-            child: replyItemRow(context, theme, replyItem.replies),
-          ),
-        ],
-      ],
+          ],
+        );
+      },
     );
   }
 
   Widget buttonAction(
     BuildContext context,
     ThemeData theme,
+    bool conciseMode,
     ReplyControl replyControl,
   ) {
     final ButtonStyle style = TextButton.styleFrom(
@@ -349,7 +360,7 @@ class ReplyItemGrpc extends StatelessWidget {
     );
     return Row(
       children: <Widget>[
-        const SizedBox(width: 36),
+        if (!conciseMode) const SizedBox(width: 36),
         SizedBox(
           height: 32,
           child: TextButton(
@@ -450,12 +461,13 @@ class ReplyItemGrpc extends StatelessWidget {
   Widget replyItemRow(
     BuildContext context,
     ThemeData theme,
+    bool conciseMode,
     List<ReplyInfo> replies,
   ) {
     final extraRow = replies.length < replyItem.count.toInt();
     late final length = replies.length + (extraRow ? 1 : 0);
     return Padding(
-      padding: const EdgeInsets.only(left: 42, right: 4),
+      padding: EdgeInsets.only(left: conciseMode ? 4 : 42, right: 4),
       child: Material(
         color: theme.colorScheme.onInverseSurface,
         borderRadius: const BorderRadius.all(Radius.circular(6)),

--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -1037,7 +1037,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
     double width =
         clampDouble(maxHeight / maxWidth * 1.08, 0.5, 0.7) * maxWidth;
     if (maxWidth >= 560) {
-      width = maxWidth - clampDouble(maxWidth - width, 280, 425);
+      width = maxWidth - clampDouble(maxWidth - width, 300, 425);
     }
     final videoWidth = isFullScreen ? maxWidth : width;
     final double height = width * 9 / 16;


### PR DESCRIPTION
## 修改

- 微调了自适应界面的判定，让屏幕比例 5:6 的横屏设备也能进入横屏模式
- 统一了 `childWhenDisabledAlmostSquare` 和 `childWhenDisabled` 的实现，让双列模式也能将视频收起
  - 已知问题：鼠标无法滚动左侧的视频推荐栏，但介于桌面下使用双列模式的情况罕见，可以无视
- 增加评论的紧凑模式，在评论区宽度小于 320dp 时自动启用

## 效果

**原有体验**：在 5:6 的折叠屏横屏下，进入双列模式（近似方形屏幕模式），视频暂停或是播完均不可将视频收起，尤其是竖屏视频观看体验极差，同时推荐视频和评论区空间也非常狭窄。

<img width="600" alt="Screenshot_20251022-183427" src="https://github.com/user-attachments/assets/df788f01-5972-49a8-aef2-8de955a7d300" />

**修改后的双列模式**：可以将视频收起，与单列模式近似。

<img width="500" alt="Screenshot_20251023-031617" src="https://github.com/user-attachments/assets/50b81b24-d299-43b5-96ac-45daa5835ce7" />

**修改后的横屏体验**：在 5:6 的折叠屏横屏下，能正常进入横屏模式，同时评论自动启用了紧凑模式，可以放下更多的评论内容。

<img width="600" alt="Screenshot_20251023-031530" src="https://github.com/user-attachments/assets/e3209d08-7f65-4c0d-ac75-d1c6cdacc724" />

### 望采纳，感谢维护者的辛勤付出！