### PR TITLE
chore: 移除 Android SDK>=31 时的图标颜色替换

### DIFF
--- a/android/app/src/main/res/values-night-v31/colors.xml
+++ b/android/app/src/main/res/values-night-v31/colors.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="ic_launcher_foreground">@android:color/system_accent1_100</color>
-    <color name="ic_launcher_background">@android:color/system_neutral1_800</color>
-</resources>

--- a/android/app/src/main/res/values-v31/colors.xml
+++ b/android/app/src/main/res/values-v31/colors.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="ic_launcher_foreground">@android:color/system_neutral2_700</color>
-    <color name="ic_launcher_background">@android:color/system_accent1_100</color>
-</resources>


### PR DESCRIPTION
替换后的效果与其他绝大多数 app 的默认行为不一致，显示不协调。主题颜色替换应该由 launcher 进行。

## 原有行为

<img height="600" alt="Screenshot_20251023_141258" src="https://github.com/user-attachments/assets/bc2ba983-e477-412e-aebe-b2c7c4637499" />

## 修改后行为

<img height="600" alt="image" src="https://github.com/user-attachments/assets/2d886944-8d44-476e-9ad0-626df86f8b02" />