### PR TITLE
fix: 安卓客户端返回键失灵

### DIFF
--- a/lib/pages/live_room/view.dart
+++ b/lib/pages/live_room/view.dart
@@ -346,8 +346,7 @@ class _LiveRoomPageState extends State<LiveRoomPage>
     }
     return popScope(
       canPop: !isFullScreen && !plPlayerController.isDesktopPip,
-      onPopInvokedWithResult: (didPop, result) =>
-          plPlayerController.onPopInvokedWithResult(didPop, result, isPortrait),
+      onPopInvokedWithResult: plPlayerController.onPopInvokedWithResult,
       child: player,
     );
   }

--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -2121,7 +2121,6 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
     videoDetailController.plPlayerController.onPopInvokedWithResult(
       didPop,
       result,
-      isPortrait,
     );
   }
 

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -1756,11 +1756,8 @@ class HeaderControlState extends State<HeaderControl>
                     size: 15,
                     color: Colors.white,
                   ),
-                  onPressed: () => plPlayerController.onPopInvokedWithResult(
-                    false,
-                    null,
-                    videoDetailCtr.isPortrait,
-                  ),
+                  onPressed: () =>
+                      plPlayerController.onPopInvokedWithResult(false, null),
                 ),
               ),
               if (!plPlayerController.isDesktopPip &&

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1746,7 +1746,7 @@ class PlPlayerController with BlockConfigMixin {
     });
   }
 
-  void onPopInvokedWithResult(bool didPop, Object? result, bool isPortrait) {
+  void onPopInvokedWithResult(bool didPop, Object? result) {
     if (didPop) {
       if (Platform.isAndroid) {
         _disableAutoEnterPipIfNeeded();

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1765,8 +1765,6 @@ class PlPlayerController with BlockConfigMixin {
       triggerFullScreen(status: false);
       return;
     }
-    if (!horizontalScreen && !isPortrait) {
-      Get.back();
-    }
+    Get.back();
   }
 }

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1746,7 +1746,7 @@ class PlPlayerController with BlockConfigMixin {
     });
   }
 
-  void onPopInvokedWithResult(bool didPop, Object? result, bool isPortrait) {
+  void onPopInvokedWithResult(bool didPop, Object? result) {
     if (didPop) {
       if (Platform.isAndroid) {
         _disableAutoEnterPipIfNeeded();
@@ -1765,6 +1765,8 @@ class PlPlayerController with BlockConfigMixin {
       triggerFullScreen(status: false);
       return;
     }
-    Get.back();
+    if (horizontalScreen || isPortrait) {
+      Get.back();
+    }
   }
 }

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1765,8 +1765,6 @@ class PlPlayerController with BlockConfigMixin {
       triggerFullScreen(status: false);
       return;
     }
-    if (horizontalScreen || isPortrait) {
-      Get.back();
-    }
+    Get.back();
   }
 }

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1746,7 +1746,7 @@ class PlPlayerController with BlockConfigMixin {
     });
   }
 
-  void onPopInvokedWithResult(bool didPop, Object? result) {
+  void onPopInvokedWithResult(bool didPop, Object? result, bool isPortrait) {
     if (didPop) {
       if (Platform.isAndroid) {
         _disableAutoEnterPipIfNeeded();


### PR DESCRIPTION
在commit 3097b5681 refactor device orientation 中，在`header_controller.dart`中的逻辑移动到`controller.dart`统一处理。引入：

```typescript
if (!horizontalScreen && !isPortrait) {
    Get.back();
}
````

此时仍可在横屏状态下正常退出全屏，由于：
```typescript
if (isFullScreen.value) {
  triggerFullScreen(status: false);
  return;
}
````

这导致在安卓客户端中，返回按钮可正常退出全屏，但无法返回到上一级。
感谢 @suhui2333 提交的 [Issue](https://github.com/HChaZZY/PiliPlus/issues/1)