### PR TITLE
fix: reset Dio adapters on iOS network switch

### DIFF
--- a/lib/http/init.dart
+++ b/lib/http/init.dart
@@ -20,7 +20,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 import 'package:dio_http2_adapter/dio_http2_adapter.dart';
-import 'package:flutter/foundation.dart' show debugPrint, kDebugMode;
+import 'package:flutter/foundation.dart' show kDebugMode;
 
 class Request {
   static const _gzipDecoder = GZipDecoder();
@@ -31,10 +31,6 @@ class Request {
   static final _enableHttp2 = Pref.enableHttp2;
   static late final Dio dio;
   static Dio? _http11Dio;
-  static bool _watchingConnectivity = false;
-  static Set<ConnectivityResult>? _lastConnectivity;
-  static Timer? _networkChangeDebounce;
-
   static Dio get http11Dio =>
       _http11Dio ??= _enableHttp2 ? _cloneHttp11Dio() : dio;
   factory Request() => _instance;
@@ -120,7 +116,18 @@ class Request {
     return h11;
   }
 
-  static HttpClientAdapter _createHttpClientAdapter() {
+  static Timer? _networkChangeDebounce;
+  static void _watchConnectivity() {
+    Connectivity().onConnectivityChanged.skip(1).listen((result) {
+      _networkChangeDebounce?.cancel();
+      _networkChangeDebounce = Timer(
+        const Duration(milliseconds: 500),
+        _resetAdaptersForNetworkChange,
+      );
+    });
+  }
+
+  static (IOHttpClientAdapter, ConnectionManager?) _createPool() {
     final bool enableSystemProxy;
     late final String systemProxyHost;
     late final int? systemProxyPort;
@@ -144,108 +151,42 @@ class Request {
               ..autoUncompress = false, // Http2Adapter没有自动解压, 统一行为
     );
 
-    if (!_enableHttp2) {
-      return http11Adapter;
-    }
-
-    return Http2Adapter(
-      ConnectionManager(
-        idleTimeout: const Duration(seconds: 15),
-        onClientCreate: enableSystemProxy
-            ? (_, config) {
-                config
-                  ..proxy = Uri(
-                    scheme: 'http',
-                    host: systemProxyHost,
-                    port: systemProxyPort,
-                  )
-                  ..onBadCertificate = (_) => true;
-              }
-            : Pref.badCertificateCallback
-            ? (_, config) {
-                config.onBadCertificate = (_) => true;
-              }
-            : null,
-      ),
-      fallbackAdapter: http11Adapter,
-    );
-  }
-
-  static void _resetAdaptersForNetworkChange() {
-    final newAdapter = _createHttpClientAdapter();
-
-    final oldPrimaryAdapter = dio.httpClientAdapter;
-    final oldFallbackAdapter = oldPrimaryAdapter is Http2Adapter
-        ? oldPrimaryAdapter.fallbackAdapter
+    final connectionManager = _enableHttp2
+        ? ConnectionManager(
+            idleTimeout: const Duration(seconds: 15),
+            onClientCreate: enableSystemProxy
+                ? (_, config) => config
+                    ..proxy = Uri(
+                      scheme: 'http',
+                      host: systemProxyHost,
+                      port: systemProxyPort,
+                    )
+                    ..onBadCertificate = (_) => true
+                : Pref.badCertificateCallback
+                ? (_, config) => config.onBadCertificate = (_) => true
+                : null,
+          )
         : null;
-    final oldHttp11Adapter = _http11Dio?.httpClientAdapter;
-
-    dio.httpClientAdapter = newAdapter;
-
-    final h11 = _http11Dio;
-    if (h11 != null) {
-      h11.httpClientAdapter = _enableHttp2
-          ? (newAdapter as Http2Adapter).fallbackAdapter
-          : newAdapter;
-    }
-
-    oldPrimaryAdapter.close(force: true);
-    if (oldHttp11Adapter != null &&
-        !identical(oldHttp11Adapter, oldPrimaryAdapter)) {
-      oldHttp11Adapter.close(force: true);
-    }
-    if (oldFallbackAdapter != null &&
-        !identical(oldFallbackAdapter, oldPrimaryAdapter) &&
-        !identical(oldFallbackAdapter, oldHttp11Adapter)) {
-      oldFallbackAdapter.close(force: true);
-    }
+    return (http11Adapter, connectionManager);
   }
 
-  static bool _sameConnectivity(
-    Set<ConnectivityResult> previous,
-    Set<ConnectivityResult> current,
-  ) => previous.length == current.length && previous.containsAll(current);
-
-  static void _watchConnectivity() {
-    if (_watchingConnectivity) {
-      return;
-    }
-    _watchingConnectivity = true;
-
-    final connectivity = Connectivity();
-    connectivity
-        .checkConnectivity()
-        .then((results) {
-          _lastConnectivity = results.toSet();
-        })
-        .onError<Exception>((error, stackTrace) {
-          if (kDebugMode) {
-            debugPrint('Request: failed to get connectivity state: $error');
-          }
-        });
-
-    connectivity.onConnectivityChanged.listen((results) {
-      final current = results.toSet();
-      final previous = _lastConnectivity;
-      _lastConnectivity = current;
-      if (previous != null && _sameConnectivity(previous, current)) {
-        return;
+  @pragma('vm:notify-debugger-on-exception')
+  static void _resetAdaptersForNetworkChange() {
+    try {
+      final (h11, connectionManager) = _createPool();
+      if (connectionManager != null) {
+        (dio.httpClientAdapter as Http2Adapter)
+          ..connectionManager.close(force: true)
+          ..connectionManager = connectionManager
+          ..fallbackAdapter.close(force: true)
+          ..fallbackAdapter = h11;
+        _http11Dio?.httpClientAdapter = h11;
+      } else {
+        dio
+          ..httpClientAdapter.close(force: true)
+          ..httpClientAdapter = h11;
       }
-
-      _networkChangeDebounce?.cancel();
-      _networkChangeDebounce = Timer(const Duration(milliseconds: 500), () {
-        try {
-          _resetAdaptersForNetworkChange();
-        } on Exception catch (error, stackTrace) {
-          if (kDebugMode) {
-            debugPrint(
-              'Request: reset adapters after network change failed: '
-              '$error\n$stackTrace',
-            );
-          }
-        }
-      });
-    });
+    } catch (_) {}
   }
 
   /*
@@ -270,7 +211,12 @@ class Request {
       persistentConnection: true,
     );
 
-    dio = Dio(options)..httpClientAdapter = _createHttpClientAdapter();
+    final (h11, connectionManager) = _createPool();
+
+    dio = Dio(options)
+      ..httpClientAdapter = _enableHttp2
+          ? Http2Adapter(connectionManager, fallbackAdapter: h11)
+          : h11;
 
     // 先于其他Interceptor
     if (Pref.retryCount != 0) {
@@ -296,9 +242,7 @@ class Request {
         return status != null && status >= 200 && status < 300;
       };
 
-    if (Platform.isIOS) {
-      _watchConnectivity();
-    }
+    if (Platform.isIOS) _watchConnectivity();
   }
 
   /*

--- a/lib/http/init.dart
+++ b/lib/http/init.dart
@@ -16,6 +16,7 @@ import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:PiliPlus/utils/utils.dart';
 import 'package:archive/archive.dart';
 import 'package:brotli/brotli.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 import 'package:dio_http2_adapter/dio_http2_adapter.dart';
@@ -115,6 +116,89 @@ class Request {
     return h11;
   }
 
+  static void _resetAdaptersForNetworkChange() {
+    final bool enableSystemProxy;
+    late final String systemProxyHost;
+    late final int? systemProxyPort;
+    if (Pref.enableSystemProxy) {
+      systemProxyHost = Pref.systemProxyHost;
+      systemProxyPort = int.tryParse(Pref.systemProxyPort);
+      enableSystemProxy = systemProxyPort != null && systemProxyHost.isNotEmpty;
+    } else {
+      enableSystemProxy = false;
+    }
+
+    final http11Adapter = IOHttpClientAdapter(
+      createHttpClient: enableSystemProxy
+          ? () => HttpClient()
+              ..idleTimeout = const Duration(seconds: 15)
+              ..autoUncompress = false
+              ..findProxy = ((_) => 'PROXY $systemProxyHost:$systemProxyPort')
+              ..badCertificateCallback = (cert, host, port) => true
+          : () => HttpClient()
+              ..idleTimeout = const Duration(seconds: 15)
+              ..autoUncompress = false, // Http2Adapter没有自动解压, 统一行为
+    );
+
+    final HttpClientAdapter newAdapter = _enableHttp2
+        ? Http2Adapter(
+            ConnectionManager(
+              idleTimeout: const Duration(seconds: 15),
+              onClientCreate: enableSystemProxy
+                  ? (_, config) {
+                      config
+                        ..proxy = Uri(
+                          scheme: 'http',
+                          host: systemProxyHost,
+                          port: systemProxyPort,
+                        )
+                        ..onBadCertificate = (_) => true;
+                    }
+                  : Pref.badCertificateCallback
+                  ? (_, config) {
+                      config.onBadCertificate = (_) => true;
+                    }
+                  : null,
+            ),
+            fallbackAdapter: http11Adapter,
+          )
+        : http11Adapter;
+
+    final oldPrimaryAdapter = dio.httpClientAdapter;
+    final oldFallbackAdapter = oldPrimaryAdapter is Http2Adapter
+        ? oldPrimaryAdapter.fallbackAdapter
+        : null;
+    final oldHttp11Adapter = _http11Dio?.httpClientAdapter;
+
+    dio.httpClientAdapter = newAdapter;
+
+    final h11 = _http11Dio;
+    if (h11 != null) {
+      h11.httpClientAdapter = _enableHttp2
+          ? (newAdapter as Http2Adapter).fallbackAdapter
+          : newAdapter;
+    }
+
+    oldPrimaryAdapter.close(force: true);
+    if (oldHttp11Adapter != null &&
+        !identical(oldHttp11Adapter, oldPrimaryAdapter)) {
+      oldHttp11Adapter.close(force: true);
+    }
+    if (oldFallbackAdapter != null &&
+        !identical(oldFallbackAdapter, oldPrimaryAdapter) &&
+        !identical(oldFallbackAdapter, oldHttp11Adapter)) {
+      oldFallbackAdapter.close(force: true);
+    }
+  }
+
+  static void _watchConnectivity() {
+    Connectivity().onConnectivityChanged.listen((_) {
+      try {
+        _resetAdaptersForNetworkChange();
+      } catch (_) {}
+    });
+  }
+
   /*
    * config it and create
    */
@@ -208,6 +292,8 @@ class Request {
       ..options.validateStatus = (int? status) {
         return status != null && status >= 200 && status < 300;
       };
+
+    _watchConnectivity();
   }
 
   /*

--- a/lib/http/init.dart
+++ b/lib/http/init.dart
@@ -20,7 +20,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 import 'package:dio_http2_adapter/dio_http2_adapter.dart';
-import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:flutter/foundation.dart' show debugPrint, kDebugMode;
 
 class Request {
   static const _gzipDecoder = GZipDecoder();
@@ -31,6 +31,10 @@ class Request {
   static final _enableHttp2 = Pref.enableHttp2;
   static late final Dio dio;
   static Dio? _http11Dio;
+  static bool _watchingConnectivity = false;
+  static Set<ConnectivityResult>? _lastConnectivity;
+  static Timer? _networkChangeDebounce;
+
   static Dio get http11Dio =>
       _http11Dio ??= _enableHttp2 ? _cloneHttp11Dio() : dio;
   factory Request() => _instance;
@@ -116,7 +120,7 @@ class Request {
     return h11;
   }
 
-  static void _resetAdaptersForNetworkChange() {
+  static HttpClientAdapter _createHttpClientAdapter() {
     final bool enableSystemProxy;
     late final String systemProxyHost;
     late final int? systemProxyPort;
@@ -140,29 +144,35 @@ class Request {
               ..autoUncompress = false, // Http2Adapter没有自动解压, 统一行为
     );
 
-    final HttpClientAdapter newAdapter = _enableHttp2
-        ? Http2Adapter(
-            ConnectionManager(
-              idleTimeout: const Duration(seconds: 15),
-              onClientCreate: enableSystemProxy
-                  ? (_, config) {
-                      config
-                        ..proxy = Uri(
-                          scheme: 'http',
-                          host: systemProxyHost,
-                          port: systemProxyPort,
-                        )
-                        ..onBadCertificate = (_) => true;
-                    }
-                  : Pref.badCertificateCallback
-                  ? (_, config) {
-                      config.onBadCertificate = (_) => true;
-                    }
-                  : null,
-            ),
-            fallbackAdapter: http11Adapter,
-          )
-        : http11Adapter;
+    if (!_enableHttp2) {
+      return http11Adapter;
+    }
+
+    return Http2Adapter(
+      ConnectionManager(
+        idleTimeout: const Duration(seconds: 15),
+        onClientCreate: enableSystemProxy
+            ? (_, config) {
+                config
+                  ..proxy = Uri(
+                    scheme: 'http',
+                    host: systemProxyHost,
+                    port: systemProxyPort,
+                  )
+                  ..onBadCertificate = (_) => true;
+              }
+            : Pref.badCertificateCallback
+            ? (_, config) {
+                config.onBadCertificate = (_) => true;
+              }
+            : null,
+      ),
+      fallbackAdapter: http11Adapter,
+    );
+  }
+
+  static void _resetAdaptersForNetworkChange() {
+    final newAdapter = _createHttpClientAdapter();
 
     final oldPrimaryAdapter = dio.httpClientAdapter;
     final oldFallbackAdapter = oldPrimaryAdapter is Http2Adapter
@@ -191,11 +201,50 @@ class Request {
     }
   }
 
+  static bool _sameConnectivity(
+    Set<ConnectivityResult> previous,
+    Set<ConnectivityResult> current,
+  ) => previous.length == current.length && previous.containsAll(current);
+
   static void _watchConnectivity() {
-    Connectivity().onConnectivityChanged.listen((_) {
-      try {
-        _resetAdaptersForNetworkChange();
-      } catch (_) {}
+    if (_watchingConnectivity) {
+      return;
+    }
+    _watchingConnectivity = true;
+
+    final connectivity = Connectivity();
+    connectivity
+        .checkConnectivity()
+        .then((results) {
+          _lastConnectivity = results.toSet();
+        })
+        .onError<Exception>((error, stackTrace) {
+          if (kDebugMode) {
+            debugPrint('Request: failed to get connectivity state: $error');
+          }
+        });
+
+    connectivity.onConnectivityChanged.listen((results) {
+      final current = results.toSet();
+      final previous = _lastConnectivity;
+      _lastConnectivity = current;
+      if (previous != null && _sameConnectivity(previous, current)) {
+        return;
+      }
+
+      _networkChangeDebounce?.cancel();
+      _networkChangeDebounce = Timer(const Duration(milliseconds: 500), () {
+        try {
+          _resetAdaptersForNetworkChange();
+        } on Exception catch (error, stackTrace) {
+          if (kDebugMode) {
+            debugPrint(
+              'Request: reset adapters after network change failed: '
+              '$error\n$stackTrace',
+            );
+          }
+        }
+      });
     });
   }
 
@@ -221,53 +270,7 @@ class Request {
       persistentConnection: true,
     );
 
-    final bool enableSystemProxy;
-    late final String systemProxyHost;
-    late final int? systemProxyPort;
-    if (Pref.enableSystemProxy) {
-      systemProxyHost = Pref.systemProxyHost;
-      systemProxyPort = int.tryParse(Pref.systemProxyPort);
-      enableSystemProxy = systemProxyPort != null && systemProxyHost.isNotEmpty;
-    } else {
-      enableSystemProxy = false;
-    }
-
-    final http11Adapter = IOHttpClientAdapter(
-      createHttpClient: enableSystemProxy
-          ? () => HttpClient()
-              ..idleTimeout = const Duration(seconds: 15)
-              ..autoUncompress = false
-              ..findProxy = ((_) => 'PROXY $systemProxyHost:$systemProxyPort')
-              ..badCertificateCallback = (cert, host, port) => true
-          : () => HttpClient()
-              ..idleTimeout = const Duration(seconds: 15)
-              ..autoUncompress = false, // Http2Adapter没有自动解压, 统一行为
-    );
-
-    dio = Dio(options)
-      ..httpClientAdapter = _enableHttp2
-          ? Http2Adapter(
-              ConnectionManager(
-                idleTimeout: const Duration(seconds: 15),
-                onClientCreate: enableSystemProxy
-                    ? (_, config) {
-                        config
-                          ..proxy = Uri(
-                            scheme: 'http',
-                            host: systemProxyHost,
-                            port: systemProxyPort,
-                          )
-                          ..onBadCertificate = (_) => true;
-                      }
-                    : Pref.badCertificateCallback
-                    ? (_, config) {
-                        config.onBadCertificate = (_) => true;
-                      }
-                    : null,
-              ),
-              fallbackAdapter: http11Adapter,
-            )
-          : http11Adapter;
+    dio = Dio(options)..httpClientAdapter = _createHttpClientAdapter();
 
     // 先于其他Interceptor
     if (Pref.retryCount != 0) {
@@ -293,7 +296,9 @@ class Request {
         return status != null && status >= 200 && status < 300;
       };
 
-    _watchConnectivity();
+    if (Platform.isIOS) {
+      _watchConnectivity();
+    }
   }
 
   /*


### PR DESCRIPTION
# 问题与复现
iOS 在 WiFi 与蜂窝网络切换时，Dio 会继续复用切网前的连接（尤其是 HTTP/2 连接池中的长连接），导致请求出现 `receive timeout`，并出现网络路径未及时切换的问题。

# 改动
- 在 `lib/http/init.dart` 中新增网络切换处理逻辑：
  - 监听 `connectivity_plus` 的网络变化事件；
  - 网络变化后重建并替换 `dio` 当前 `httpClientAdapter`；
  - 同步更新 `http11Dio` 的 adapter；
  - 强制关闭旧 adapter，避免继续复用旧 socket/连接池。
- 在 `Request` 初始化完成后启动网络变化监听，确保运行期切网可自动生效。

# 效果
- iOS 从 WiFi 切到蜂窝（或反向切换）后，请求可及时走新网络建连；
- 降低切网瞬间因旧连接复用引发的 `receive timeout` 概率；
- 不影响现有请求签名、业务参数与接口行为。

# 验证
1. iOS 真机启动 App，进入会触发网络请求的页面（如推荐流）。
2. 在请求过程中执行 WiFi ↔ 蜂窝切换。
3. 观察切网后请求恢复情况，确认不再持续出现 `receive timeout`。