### PR TITLE
use linux_webview_window to support linux geetest

### DIFF
--- a/lib/pages/login/controller.dart
+++ b/lib/pages/login/controller.dart
@@ -313,9 +313,6 @@ class LoginPageController extends GetxController
       }
       if (data['status'] == 2) {
         SmartDialog.showToast(data['message']);
-        // if (Platform.isLinux) {
-        //   return;
-        // }
         // return;
         //{"code":0,"message":"0","ttl":1,"data":{"status":2,"message":"本次登录环境存在风险, 需使用手机号进行验证或绑定","url":"https://passport.bilibili.com/h5-app/passport/risk/verify?tmp_token=9e785433940891dfa78f033fb7928181&request_id=e5a6d6480df04097870be56c6e60f7ef&source=risk","token_info":null,"cookie_info":null,"sso":null,"is_new":false,"is_tourist":false}}
         String url = data['url']!;

--- a/lib/pages/login/controller.dart
+++ b/lib/pages/login/controller.dart
@@ -313,9 +313,9 @@ class LoginPageController extends GetxController
       }
       if (data['status'] == 2) {
         SmartDialog.showToast(data['message']);
-        if (Platform.isLinux) {
-          return;
-        }
+        // if (Platform.isLinux) {
+        //   return;
+        // }
         // return;
         //{"code":0,"message":"0","ttl":1,"data":{"status":2,"message":"本次登录环境存在风险, 需使用手机号进行验证或绑定","url":"https://passport.bilibili.com/h5-app/passport/risk/verify?tmp_token=9e785433940891dfa78f033fb7928181&request_id=e5a6d6480df04097870be56c6e60f7ef&source=risk","token_info":null,"cookie_info":null,"sso":null,"is_new":false,"is_tourist":false}}
         String url = data['url']!;
@@ -520,7 +520,7 @@ class LoginPageController extends GetxController
         case 0:
           // login success
           break;
-        case -105 when (!Platform.isLinux):
+        case -105:
           String captureUrl = res['data']['url'];
           Uri captureUri = Uri.parse(captureUrl);
           captchaData.token = captureUri.queryParameters['recaptcha_token']!;

--- a/lib/pages/login/geetest/geetest_webview_dialog.dart
+++ b/lib/pages/login/geetest/geetest_webview_dialog.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:PiliPlus/http/browser_ua.dart';
 import 'package:PiliPlus/http/init.dart';
@@ -9,8 +10,9 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:get/get.dart';
+import 'package:webview_all/webview_all.dart';
 
-class GeetestWebviewDialog extends StatelessWidget {
+class GeetestWebviewDialog extends StatefulWidget {
   const GeetestWebviewDialog(this.gt, this.challenge, {super.key});
 
   final String gt;
@@ -63,63 +65,132 @@ class GeetestWebviewDialog extends StatelessWidget {
   }
 
   @override
+  State<GeetestWebviewDialog> createState() => _GeetestWebviewDialogState();
+}
+
+class _GeetestWebviewDialogState extends State<GeetestWebviewDialog> {
+  late final bool _isLinux = Platform.isLinux;
+  late final Future<LoadingState<String>> _future;
+  late WebViewController? _linuxController;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = GeetestWebviewDialog._getConfig(widget.gt, widget.challenge);
+
+    if (_isLinux) {
+      _linuxController = WebViewController()
+        ..setJavaScriptMode(JavaScriptMode.unrestricted)
+        ..setUserAgent(BrowserUa.mob)
+        ..addJavaScriptChannel(
+          'geetestResult',
+          onMessageReceived: (JavaScriptMessage message) {
+            try {
+              final Map<String, dynamic> data = jsonDecode(message.message);
+              if (data['type'] == 'success' &&
+                  data['payload'] is Map<String, dynamic>) {
+                Get.back(result: data['payload']);
+              } else if (data['type'] == 'error') {
+                debugPrint('geetest error: ${data['payload']}');
+              }
+            } catch (_) {
+              debugPrint('geetest invalid: ${message.message}');
+            }
+          },
+        )
+        ..setNavigationDelegate(
+          NavigationDelegate(
+            onPageFinished: (_) async {
+              final config = await _future;
+              if (!mounted) return;
+              if (config case Success(:final response)) {
+                await _linuxController!.runJavaScript('''
+                  let t=Geetest($response)
+                    .onSuccess(()=>R("success",t.getValidate()))
+                    .onError((o)=>R("error",o));
+                  t.onReady(()=> {
+                    t.verify();
+                  });
+                ''');
+              } else {
+                config.toast();
+                Get.back();
+              }
+            },
+          ),
+        );
+
+      const initialHtml =
+          '''
+          <!DOCTYPE html><html><head></head><body>
+          <script src="${GeetestWebviewDialog._geetestJsUri}"></script>
+          <script>
+          function R(n,o){
+            window.geetestResult.postMessage(JSON.stringify({type: n, payload: o}));
+          }
+          </script>
+          </body></html>
+          ''';
+      _linuxController!.loadHtmlString(initialHtml);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final future = _getConfig(gt, challenge);
     return AlertDialog(
       title: const Text('验证码'),
       content: SizedBox(
         width: 300,
         height: 400,
-        child: InAppWebView(
-          webViewEnvironment: webViewEnvironment,
-          initialSettings: InAppWebViewSettings(
-            clearCache: true,
-            javaScriptEnabled: true,
-            forceDark: ForceDark.AUTO,
-            useHybridComposition: false,
-            algorithmicDarkeningAllowed: true,
-            useShouldOverrideUrlLoading: true,
-            userAgent: BrowserUa.mob,
-            mixedContentMode: MixedContentMode.MIXED_CONTENT_ALWAYS_ALLOW,
-          ),
-          initialData: InAppWebViewInitialData(
-            data:
-                '<!DOCTYPE html><html><head></head><body><script src="$_geetestJsUri"></script><script>function R(n,o){flutter_inappwebview.callHandler(n,o)}</script></body></html>',
-          ),
-          onWebViewCreated: (ctr) {
-            ctr
-              ..addJavaScriptHandler(
-                handlerName: 'success',
-                callback: (args) {
-                  if (args.isNotEmpty) {
-                    if (args[0] case Map<String, dynamic> data) {
-                      Get.back(result: data);
-                      return;
-                    }
+        child: _isLinux
+            ? WebViewWidget(controller: _linuxController!)
+            : InAppWebView(
+                webViewEnvironment: webViewEnvironment,
+                initialSettings: InAppWebViewSettings(
+                  clearCache: true,
+                  javaScriptEnabled: true,
+                  forceDark: ForceDark.AUTO,
+                  useHybridComposition: false,
+                  algorithmicDarkeningAllowed: true,
+                  useShouldOverrideUrlLoading: true,
+                  userAgent: BrowserUa.mob,
+                  mixedContentMode: MixedContentMode.MIXED_CONTENT_ALWAYS_ALLOW,
+                ),
+                initialData: InAppWebViewInitialData(
+                  data:
+                      '<!DOCTYPE html><html><head></head><body><script src="${GeetestWebviewDialog._geetestJsUri}"></script><script>function R(n,o){flutter_inappwebview.callHandler(n,o)}</script></body></html>',
+                ),
+                onWebViewCreated: (ctr) {
+                  ctr
+                    ..addJavaScriptHandler(
+                      handlerName: 'success',
+                      callback: (args) {
+                        if (args.isNotEmpty &&
+                            args[0] is Map<String, dynamic>) {
+                          Get.back(result: args[0]);
+                        } else {
+                          debugPrint('geetest invalid result: $args');
+                        }
+                      },
+                    )
+                    ..addJavaScriptHandler(
+                      handlerName: 'error',
+                      callback: (args) => debugPrint('geetest error: $args'),
+                    );
+                },
+                onLoadStop: (ctr, _) async {
+                  final config = await _future;
+                  if (config case Success(:final response)) {
+                    ctr.evaluateJavascript(
+                      source:
+                          'let t=Geetest($response).onSuccess(()=>R("success",t.getValidate())).onError((o)=>R("error",o));t.onReady(()=>t.verify());',
+                    );
+                  } else {
+                    config.toast();
+                    Get.back();
                   }
-                  debugPrint('geetest invalid result: $args');
                 },
-              )
-              ..addJavaScriptHandler(
-                handlerName: 'error',
-                callback: (args) {
-                  debugPrint('geetest error: $args');
-                },
-              );
-          },
-          onLoadStop: (ctr, _) async {
-            final config = await future;
-            if (config case Success(:final response)) {
-              ctr.evaluateJavascript(
-                source:
-                    'let t=Geetest($response).onSuccess(()=>R("success",t.getValidate())).onError((o)=>R("error",o));t.onReady(()=>t.verify());',
-              );
-            } else {
-              config.toast();
-              Get.back();
-            }
-          },
-        ),
+              ),
       ),
       actions: [
         TextButton(

--- a/lib/pages/login/geetest/geetest_webview_dialog.dart
+++ b/lib/pages/login/geetest/geetest_webview_dialog.dart
@@ -9,8 +9,8 @@ import 'package:PiliPlus/utils/accounts/account.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:desktop_webview_window/desktop_webview_window.dart';
 import 'package:get/get.dart';
-import 'package:webview_all/webview_all.dart';
 
 class GeetestWebviewDialog extends StatefulWidget {
   const GeetestWebviewDialog(this.gt, this.challenge, {super.key});
@@ -18,8 +18,26 @@ class GeetestWebviewDialog extends StatefulWidget {
   final String gt;
   final String challenge;
 
+  @override
+  State<GeetestWebviewDialog> createState() => _GeetestWebviewDialogState();
+}
+
+class _GeetestWebviewDialogState extends State<GeetestWebviewDialog> {
   static const _geetestJsUri =
       'https://static.geetest.com/static/js/fullpage.0.0.0.js';
+
+  late Future<LoadingState<String>> _future;
+  Webview? _linuxWebview;
+  bool _linuxWebviewLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _getConfig(widget.gt, widget.challenge);
+    if (Platform.isLinux) {
+      _initLinuxWebview();
+    }
+  }
 
   static Future<LoadingState<String>> _getConfig(
     String gt,
@@ -64,133 +82,167 @@ class GeetestWebviewDialog extends StatefulWidget {
     return Error(res.data['message']);
   }
 
-  @override
-  State<GeetestWebviewDialog> createState() => _GeetestWebviewDialogState();
-}
+  Future<void> _initLinuxWebview() async {
+    setState(() {
+      _linuxWebviewLoading = true;
+    });
 
-class _GeetestWebviewDialogState extends State<GeetestWebviewDialog> {
-  late final bool _isLinux = Platform.isLinux;
-  late final Future<LoadingState<String>> _future;
-  late WebViewController? _linuxController;
+    final config = await _future;
+    if (config is Error) {
+      if (mounted) {
+        config.toast();
+        Get.back();
+      }
+      return;
+    }
 
-  @override
-  void initState() {
-    super.initState();
-    _future = GeetestWebviewDialog._getConfig(widget.gt, widget.challenge);
+    final response = (config as Success<String>).response;
 
-    if (_isLinux) {
-      _linuxController = WebViewController()
-        ..setJavaScriptMode(JavaScriptMode.unrestricted)
-        ..setUserAgent(BrowserUa.mob)
-        ..addJavaScriptChannel(
-          'geetestResult',
-          onMessageReceived: (JavaScriptMessage message) {
-            try {
-              final Map<String, dynamic> data = jsonDecode(message.message);
-              if (data['type'] == 'success' &&
-                  data['payload'] is Map<String, dynamic>) {
-                Get.back(result: data['payload']);
-              } else if (data['type'] == 'error') {
-                debugPrint('geetest error: ${data['payload']}');
-              }
-            } catch (_) {
-              debugPrint('geetest invalid: ${message.message}');
-            }
-          },
-        )
-        ..setNavigationDelegate(
-          NavigationDelegate(
-            onPageFinished: (_) async {
-              final config = await _future;
-              if (!mounted) return;
-              if (config case Success(:final response)) {
-                await _linuxController!.runJavaScript('''
-                  let t=Geetest($response)
-                    .onSuccess(()=>R("success",t.getValidate()))
-                    .onError((o)=>R("error",o));
-                  t.onReady(()=> {
-                    t.verify();
-                  });
-                ''');
-              } else {
-                config.toast();
-                Get.back();
-              }
-            },
-          ),
-        );
+    _linuxWebview = await WebviewWindow.create(
+      configuration: const CreateConfiguration(
+        windowWidth: 300,
+        windowHeight: 400,
+        title: "验证码",
+      ),
+    );
 
-      const initialHtml =
-          '''
-          <!DOCTYPE html><html><head></head><body>
-          <script src="${GeetestWebviewDialog._geetestJsUri}"></script>
-          <script>
-          function R(n,o){
-            window.geetestResult.postMessage(JSON.stringify({type: n, payload: o}));
-          }
-          </script>
-          </body></html>
-          ''';
-      _linuxController!.loadHtmlString(initialHtml);
+    _linuxWebview!.addOnWebMessageReceivedCallback((msg) {
+      final msgStr = msg.toString();
+      if (msgStr.startsWith("success:")) {
+        final dataStr = msgStr.substring("success:".length);
+        try {
+          final data = jsonDecode(dataStr);
+          Get.back(result: data);
+        } catch (e) {
+          debugPrint('geetest decode error: $e');
+        }
+      } else if (msgStr.startsWith("error:")) {
+        debugPrint('geetest error: $msgStr');
+      }
+    });
+
+    _linuxWebview!.onClose.whenComplete(() {
+      if (mounted) {
+        Get.back();
+      }
+    });
+
+    final html =
+        '''
+<!DOCTYPE html><html><head></head><body>
+<script src="$_geetestJsUri"></script>
+<script>
+  function R(n,o){
+     window.webkit.messageHandlers.msgToNative.postMessage(n + ':' + JSON.stringify(o));
+  }
+  let t=Geetest($response).onSuccess(()=>R("success",t.getValidate())).onError((o)=>R("error",o));
+  t.onReady(()=>t.verify());
+</script>
+</body></html>
+''';
+
+    final tempDir = Directory.systemTemp;
+    final file = File(
+      '${tempDir.path}/geetest_${DateTime.now().millisecondsSinceEpoch}.html',
+    );
+    await file.writeAsString(html);
+
+    _linuxWebview!.launch('file://${file.path}');
+
+    if (mounted) {
+      setState(() {
+        _linuxWebviewLoading = false;
+      });
     }
   }
 
   @override
+  void dispose() {
+    _linuxWebview?.close();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    if (Platform.isLinux) {
+      return AlertDialog(
+        title: const Text('验证码'),
+        content: SizedBox(
+          width: 300,
+          height: 400,
+          child: Center(
+            child: _linuxWebviewLoading
+                ? const CircularProgressIndicator()
+                : const Text('请在弹出的新窗口中完成验证'),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: Get.back,
+            child: Text(
+              '取消',
+              style: TextStyle(color: ColorScheme.of(context).outline),
+            ),
+          ),
+        ],
+      );
+    }
+
     return AlertDialog(
       title: const Text('验证码'),
       content: SizedBox(
         width: 300,
         height: 400,
-        child: _isLinux
-            ? WebViewWidget(controller: _linuxController!)
-            : InAppWebView(
-                webViewEnvironment: webViewEnvironment,
-                initialSettings: InAppWebViewSettings(
-                  clearCache: true,
-                  javaScriptEnabled: true,
-                  forceDark: ForceDark.AUTO,
-                  useHybridComposition: false,
-                  algorithmicDarkeningAllowed: true,
-                  useShouldOverrideUrlLoading: true,
-                  userAgent: BrowserUa.mob,
-                  mixedContentMode: MixedContentMode.MIXED_CONTENT_ALWAYS_ALLOW,
-                ),
-                initialData: InAppWebViewInitialData(
-                  data:
-                      '<!DOCTYPE html><html><head></head><body><script src="${GeetestWebviewDialog._geetestJsUri}"></script><script>function R(n,o){flutter_inappwebview.callHandler(n,o)}</script></body></html>',
-                ),
-                onWebViewCreated: (ctr) {
-                  ctr
-                    ..addJavaScriptHandler(
-                      handlerName: 'success',
-                      callback: (args) {
-                        if (args.isNotEmpty &&
-                            args[0] is Map<String, dynamic>) {
-                          Get.back(result: args[0]);
-                        } else {
-                          debugPrint('geetest invalid result: $args');
-                        }
-                      },
-                    )
-                    ..addJavaScriptHandler(
-                      handlerName: 'error',
-                      callback: (args) => debugPrint('geetest error: $args'),
-                    );
-                },
-                onLoadStop: (ctr, _) async {
-                  final config = await _future;
-                  if (config case Success(:final response)) {
-                    ctr.evaluateJavascript(
-                      source:
-                          'let t=Geetest($response).onSuccess(()=>R("success",t.getValidate())).onError((o)=>R("error",o));t.onReady(()=>t.verify());',
-                    );
-                  } else {
-                    config.toast();
-                    Get.back();
+        child: InAppWebView(
+          webViewEnvironment: webViewEnvironment,
+          initialSettings: InAppWebViewSettings(
+            clearCache: true,
+            javaScriptEnabled: true,
+            forceDark: ForceDark.AUTO,
+            useHybridComposition: false,
+            algorithmicDarkeningAllowed: true,
+            useShouldOverrideUrlLoading: true,
+            userAgent: BrowserUa.mob,
+            mixedContentMode: MixedContentMode.MIXED_CONTENT_ALWAYS_ALLOW,
+          ),
+          initialData: InAppWebViewInitialData(
+            data:
+                '<!DOCTYPE html><html><head></head><body><script src="$_geetestJsUri"></script><script>function R(n,o){flutter_inappwebview.callHandler(n,o)}</script></body></html>',
+          ),
+          onWebViewCreated: (ctr) {
+            ctr
+              ..addJavaScriptHandler(
+                handlerName: 'success',
+                callback: (args) {
+                  if (args.isNotEmpty) {
+                    if (args[0] case Map<String, dynamic> data) {
+                      Get.back(result: data);
+                      return;
+                    }
                   }
+                  debugPrint('geetest invalid result: $args');
                 },
-              ),
+              )
+              ..addJavaScriptHandler(
+                handlerName: 'error',
+                callback: (args) {
+                  debugPrint('geetest error: $args');
+                },
+              );
+          },
+          onLoadStop: (ctr, _) async {
+            final config = await _future;
+            if (config case Success(:final response)) {
+              ctr.evaluateJavascript(
+                source:
+                    'let t=Geetest($response).onSuccess(()=>R("success",t.getValidate())).onError((o)=>R("error",o));t.onReady(()=>t.verify());',
+              );
+            } else {
+              config.toast();
+              Get.back();
+            }
+          },
+        ),
       ),
       actions: [
         TextButton(

--- a/lib/pages/login/geetest/geetest_webview_dialog.dart
+++ b/lib/pages/login/geetest/geetest_webview_dialog.dart
@@ -1,15 +1,15 @@
-import 'dart:convert';
-import 'dart:io';
+import 'dart:convert' show jsonDecode, jsonEncode;
+import 'dart:io' show Platform, Directory, File;
 
 import 'package:PiliPlus/http/browser_ua.dart';
 import 'package:PiliPlus/http/init.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/main.dart';
 import 'package:PiliPlus/utils/accounts/account.dart';
+import 'package:desktop_webview_window/desktop_webview_window.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
-import 'package:desktop_webview_window/desktop_webview_window.dart';
 import 'package:get/get.dart';
 
 class GeetestWebviewDialog extends StatefulWidget {
@@ -26,9 +26,9 @@ class _GeetestWebviewDialogState extends State<GeetestWebviewDialog> {
   static const _geetestJsUri =
       'https://static.geetest.com/static/js/fullpage.0.0.0.js';
 
-  late Future<LoadingState<String>> _future;
+  late final Future<LoadingState<String>> _future;
   Webview? _linuxWebview;
-  bool _linuxWebviewLoading = false;
+  late bool _linuxWebviewLoading = true;
 
   @override
   void initState() {
@@ -83,16 +83,15 @@ class _GeetestWebviewDialogState extends State<GeetestWebviewDialog> {
   }
 
   Future<void> _initLinuxWebview() async {
-    setState(() {
-      _linuxWebviewLoading = true;
-    });
-
     final config = await _future;
+
+    if (!mounted) {
+      return;
+    }
+
     if (config is Error) {
-      if (mounted) {
-        config.toast();
-        Get.back();
-      }
+      config.toast();
+      Get.back();
       return;
     }
 
@@ -105,6 +104,11 @@ class _GeetestWebviewDialogState extends State<GeetestWebviewDialog> {
         title: "验证码",
       ),
     );
+
+    if (!mounted) {
+      _closeLinuxWebview();
+      return;
+    }
 
     _linuxWebview!.addOnWebMessageReceivedCallback((msg) {
       final msgStr = msg.toString();
@@ -147,6 +151,11 @@ class _GeetestWebviewDialogState extends State<GeetestWebviewDialog> {
     );
     await file.writeAsString(html);
 
+    if (!mounted) {
+      _closeLinuxWebview();
+      return;
+    }
+
     _linuxWebview!.launch('file://${file.path}');
 
     if (mounted) {
@@ -156,9 +165,14 @@ class _GeetestWebviewDialogState extends State<GeetestWebviewDialog> {
     }
   }
 
+  void _closeLinuxWebview() {
+    _linuxWebview?.close();
+    _linuxWebview = null;
+  }
+
   @override
   void dispose() {
-    _linuxWebview?.close();
+    _closeLinuxWebview();
     super.dispose();
   }
 
@@ -232,6 +246,7 @@ class _GeetestWebviewDialogState extends State<GeetestWebviewDialog> {
           },
           onLoadStop: (ctr, _) async {
             final config = await _future;
+            if (!mounted) return;
             if (config case Success(:final response)) {
               ctr.evaluateJavascript(
                 source:

--- a/lib/pages/login/view.dart
+++ b/lib/pages/login/view.dart
@@ -379,7 +379,6 @@ class _LoginPageState extends State<LoginPage> {
                 Builder(
                   builder: (context) {
                     return PopupMenuButton(
-                      enabled: true,
                       padding: EdgeInsets.zero,
                       tooltip:
                           '选择国际冠码，'
@@ -427,7 +426,6 @@ class _LoginPageState extends State<LoginPage> {
                 const SizedBox(width: 6),
                 Expanded(
                   child: TextField(
-                    enabled: true,
                     controller: _loginPageCtr.telTextController,
                     keyboardType: TextInputType.number,
                     inputFormatters: <TextInputFormatter>[
@@ -459,7 +457,6 @@ class _LoginPageState extends State<LoginPage> {
               children: [
                 Expanded(
                   child: TextField(
-                    enabled: true,
                     controller: _loginPageCtr.smsCodeTextController,
                     decoration: const InputDecoration(
                       prefixIcon: Icon(Icons.sms_outlined),

--- a/lib/pages/login/view.dart
+++ b/lib/pages/login/view.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'dart:ui';
 
 import 'package:PiliPlus/common/constants.dart';
@@ -380,7 +379,7 @@ class _LoginPageState extends State<LoginPage> {
                 Builder(
                   builder: (context) {
                     return PopupMenuButton(
-                      enabled: !Platform.isLinux,
+                      enabled: true,
                       padding: EdgeInsets.zero,
                       tooltip:
                           '选择国际冠码，'
@@ -428,7 +427,7 @@ class _LoginPageState extends State<LoginPage> {
                 const SizedBox(width: 6),
                 Expanded(
                   child: TextField(
-                    enabled: !Platform.isLinux,
+                    enabled: true,
                     controller: _loginPageCtr.telTextController,
                     keyboardType: TextInputType.number,
                     inputFormatters: <TextInputFormatter>[
@@ -460,7 +459,7 @@ class _LoginPageState extends State<LoginPage> {
               children: [
                 Expanded(
                   child: TextField(
-                    enabled: !Platform.isLinux,
+                    enabled: true,
                     controller: _loginPageCtr.smsCodeTextController,
                     decoration: const InputDecoration(
                       prefixIcon: Icon(Icons.sms_outlined),
@@ -475,11 +474,9 @@ class _LoginPageState extends State<LoginPage> {
                 ),
                 Obx(
                   () => TextButton.icon(
-                    onPressed: !Platform.isLinux
-                        ? _loginPageCtr.smsSendCooldown > 0
-                              ? null
-                              : _loginPageCtr.sendSmsCode
-                        : null,
+                    onPressed: _loginPageCtr.smsSendCooldown > 0
+                        ? null
+                        : _loginPageCtr.sendSmsCode,
                     icon: const Icon(Icons.send),
                     label: Text(
                       _loginPageCtr.smsSendCooldown > 0
@@ -494,7 +491,7 @@ class _LoginPageState extends State<LoginPage> {
         ),
         const SizedBox(height: 20),
         OutlinedButton.icon(
-          onPressed: !Platform.isLinux ? _loginPageCtr.loginBySmsCode : null,
+          onPressed: _loginPageCtr.loginBySmsCode,
           icon: const Icon(Icons.login),
           label: const Text('登录'),
         ),

--- a/lib/utils/request_utils.dart
+++ b/lib/utils/request_utils.dart
@@ -493,10 +493,6 @@ abstract final class RequestUtils {
     String vVoucher,
     ValueChanged<String> onSuccess,
   ) async {
-    // if (Platform.isLinux) {
-    //   return;
-    // }
-
     final res = await ValidateHttp.gaiaVgateRegister(vVoucher);
     if (!res.isSuccess) {
       res.toast();

--- a/lib/utils/request_utils.dart
+++ b/lib/utils/request_utils.dart
@@ -493,9 +493,9 @@ abstract final class RequestUtils {
     String vVoucher,
     ValueChanged<String> onSuccess,
   ) async {
-    if (Platform.isLinux) {
-      return;
-    }
+    // if (Platform.isLinux) {
+    //   return;
+    // }
 
     final res = await ValidateHttp.gaiaVgateRegister(vVoucher);
     if (!res.isSuccess) {

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -46,9 +46,9 @@ static void my_application_activate(GApplication *application) {
   // if future cases occur).
 
   const gboolean use_header_bar = [window]() -> gboolean {
-    if (g_file_test(
-        g_build_filename(g_get_user_data_dir(), "com.example.piliplus", "use_ssd", NULL),
-        G_FILE_TEST_EXISTS))
+    if (g_file_test(g_build_filename(g_get_user_data_dir(),
+                                     "com.example.piliplus", "use_ssd", NULL),
+                    G_FILE_TEST_EXISTS))
       return FALSE;
 
 #ifdef GDK_WINDOWING_X11
@@ -85,8 +85,16 @@ static void my_application_activate(GApplication *application) {
   // for transparent.
   gdk_rgba_parse(&background_color, "#000000");
   fl_view_set_background_color(view, &background_color);
+  gtk_widget_set_hexpand(GTK_WIDGET(view), TRUE);
+  gtk_widget_set_vexpand(GTK_WIDGET(view), TRUE);
   gtk_widget_show(GTK_WIDGET(view));
-  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  GtkWidget *overlay = gtk_overlay_new();
+  gtk_widget_set_hexpand(overlay, TRUE);
+  gtk_widget_set_vexpand(overlay, TRUE);
+  gtk_widget_show(overlay);
+  gtk_container_add(GTK_CONTAINER(overlay), GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), overlay);
 
   // Show the window when Flutter renders.
   // Requires the view to be realized so we can start rendering.

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -85,16 +85,8 @@ static void my_application_activate(GApplication *application) {
   // for transparent.
   gdk_rgba_parse(&background_color, "#000000");
   fl_view_set_background_color(view, &background_color);
-  gtk_widget_set_hexpand(GTK_WIDGET(view), TRUE);
-  gtk_widget_set_vexpand(GTK_WIDGET(view), TRUE);
   gtk_widget_show(GTK_WIDGET(view));
-
-  GtkWidget *overlay = gtk_overlay_new();
-  gtk_widget_set_hexpand(overlay, TRUE);
-  gtk_widget_set_vexpand(overlay, TRUE);
-  gtk_widget_show(overlay);
-  gtk_container_add(GTK_CONTAINER(overlay), GTK_WIDGET(view));
-  gtk_container_add(GTK_CONTAINER(window), overlay);
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
   // Show the window when Flutter renders.
   // Requires the view to be realized so we can start rendering.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2030,6 +2030,62 @@ packages:
       url: "https://github.com/wgh136/webdav_client.git"
     source: git
     version: "1.2.2"
+  webview_all:
+    dependency: "direct main"
+    description:
+      name: webview_all
+      sha256: e66f1a2d820a44b053d4b76d34091b3f696355649b51a09de4a7d5c8765213d6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  webview_all_linux:
+    dependency: transitive
+    description:
+      name: webview_all_linux
+      sha256: "328d63ec38d4f0626fd0f7eec9ad47601cff4874b28d6ef56bbd0d663d206caf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.4"
+  webview_all_web:
+    dependency: transitive
+    description:
+      name: webview_all_web
+      sha256: "0dafb1163de9dce06a3bc0f9f11190ac6da9d6033b46410e1b8ff15aae98d8e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2"
+  webview_all_windows:
+    dependency: transitive
+    description:
+      name: webview_all_windows
+      sha256: "6bcd9173ea709976005c96dcef75d596d6e2a58192e859f574d305dbee9954b6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: f560f57d0f529c1dcdaf4edc3a3217b099560622f9f4a10b6bdbb566553c61ea
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.11.0"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "1221c1b12f5278791042f2ec2841743784cf25c5a644e23d6680e5d718824f04"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.1"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: e15d8828e014291324a4d0cf6e272090167f4fa5673ffcf8fe446f4a4cd35861
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.24.3"
   win32:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -392,7 +392,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "297b39532c426263d2fa9fde4d70d2b5bdfc8059"
+      resolved-ref: b429f8ba6b8a99cd0f7eb5fe8d1621f325635c3d
       url: "https://github.com/Predidit/linux_webview_window"
     source: git
     version: "0.2.4"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -387,6 +387,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  desktop_webview_window:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: main
+      resolved-ref: "297b39532c426263d2fa9fde4d70d2b5bdfc8059"
+      url: "https://github.com/Predidit/linux_webview_window"
+    source: git
+    version: "0.2.4"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -2030,62 +2039,6 @@ packages:
       url: "https://github.com/wgh136/webdav_client.git"
     source: git
     version: "1.2.2"
-  webview_all:
-    dependency: "direct main"
-    description:
-      name: webview_all
-      sha256: e66f1a2d820a44b053d4b76d34091b3f696355649b51a09de4a7d5c8765213d6
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
-  webview_all_linux:
-    dependency: transitive
-    description:
-      name: webview_all_linux
-      sha256: "328d63ec38d4f0626fd0f7eec9ad47601cff4874b28d6ef56bbd0d663d206caf"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.4"
-  webview_all_web:
-    dependency: transitive
-    description:
-      name: webview_all_web
-      sha256: "0dafb1163de9dce06a3bc0f9f11190ac6da9d6033b46410e1b8ff15aae98d8e1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.2"
-  webview_all_windows:
-    dependency: transitive
-    description:
-      name: webview_all_windows
-      sha256: "6bcd9173ea709976005c96dcef75d596d6e2a58192e859f574d305dbee9954b6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.2"
-  webview_flutter_android:
-    dependency: transitive
-    description:
-      name: webview_flutter_android
-      sha256: f560f57d0f529c1dcdaf4edc3a3217b099560622f9f4a10b6bdbb566553c61ea
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.11.0"
-  webview_flutter_platform_interface:
-    dependency: transitive
-    description:
-      name: webview_flutter_platform_interface
-      sha256: "1221c1b12f5278791042f2ec2841743784cf25c5a644e23d6680e5d718824f04"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.15.1"
-  webview_flutter_wkwebview:
-    dependency: transitive
-    description:
-      name: webview_flutter_wkwebview
-      sha256: e15d8828e014291324a4d0cf6e272090167f4fa5673ffcf8fe446f4a4cd35861
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.24.3"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,7 +79,10 @@ dependencies:
   # 浏览器
   # webview_flutter: ^4.10.0
   flutter_inappwebview: ^6.1.5
-  webview_all: ^1.0.3
+  desktop_webview_window:
+    git:
+      url: https://github.com/Predidit/linux_webview_window
+      ref: main
   # 解决sliver滑动不同步
   # extended_nested_scroll_view: ^6.2.1
   extended_nested_scroll_view:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,7 @@ dependencies:
   # 浏览器
   # webview_flutter: ^4.10.0
   flutter_inappwebview: ^6.1.5
+  webview_all: ^1.0.3
   # 解决sliver滑动不同步
   # extended_nested_scroll_view: ^6.2.1
   extended_nested_scroll_view:


### PR DESCRIPTION
使用 [webview_all](https://pub.dev/packages/webview_all) 支持了(?) Linux 端的极验、短信登录   
好消息：密码登录/短信登录在 Linux 上完全可用了  
坏消息：有 bug，第一次写 flutter 应用，不会修  
bug：极验窗口出现的时候不会自动显示出验证的界面，如下图所示：
<img width="1770" height="1152" alt="屏幕截图_20260413_224258" src="https://github.com/user-attachments/assets/d0afb02f-a8dc-4c3f-8800-c0abd51f6441" />
此时，只要将鼠标移到“取消”上面（hover），验证的界面就会显示，然后只需要通过人机验证就能获取到验证码  
然而这个验证界面是个幽灵窗口，把 app 最小化，这个验证界面就会消失不见，一 hover 就会再次出现，而且kde桌面自带的截图无法截取到这个窗口  
通过人机验证后， app 出现异常行为：距离右边约 75px ，距离底边约 100px 的一个直角形区域视觉可见，然而实际上却消失了，我使用 kwin 工具检查了这块区域的属性，显示的是 app 后面的窗口；此时 app 内任何按键输入都会无效化，无法进行输入，解决方法是按一下 TAB 键，然后就能输入了；所有异常行为会在应用重启后消失  
我认为上述现象为大多数 Linux 用户（或许我不能代表大多数 Linux 用户？）可接受的范围内，可以自适应一下，毕竟只要登录成功，重启应用，所有的异常现象均会消失，这比完全无法在 Linux 上使用密码/短信登录好的多