### PR TITLE
fix: 定时关闭退出APP前同步视频进度

### DIFF
--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -17,7 +17,6 @@ import 'package:PiliPlus/models/user/danmaku_rule.dart';
 import 'package:PiliPlus/models/video/play/url.dart';
 import 'package:PiliPlus/models_new/video/video_shot/data.dart';
 import 'package:PiliPlus/pages/danmaku/danmaku_model.dart';
-import 'package:PiliPlus/pages/mine/controller.dart';
 import 'package:PiliPlus/pages/sponsor_block/block_mixin.dart';
 import 'package:PiliPlus/plugin/pl_player/models/data_source.dart';
 import 'package:PiliPlus/plugin/pl_player/models/data_status.dart';
@@ -1525,7 +1524,7 @@ class PlPlayerController with BlockConfigMixin {
   // 记录播放记录
   Future<void>? makeHeartBeat(
     int progress, {
-    HeartBeatType type = HeartBeatType.playing,
+    HeartBeatType type = .playing,
     bool isManual = false,
     dynamic aid,
     dynamic bvid,
@@ -1535,22 +1534,12 @@ class PlPlayerController with BlockConfigMixin {
     dynamic pgcType,
     VideoType? videoType,
   }) {
-    if (isLive) {
+    if (isLive ||
+        !enableHeart ||
+        progress == 0 ||
+        (playerStatus.isPaused && !isManual)) {
       return null;
     }
-    if (!enableHeart || MineController.anonymity.value || progress == 0) {
-      return null;
-    } else if (playerStatus.isPaused) {
-      if (!isManual) {
-        return null;
-      }
-    }
-    bool isComplete =
-        playerStatus.isCompleted || type == HeartBeatType.completed;
-    if ((duration.value - position).inMilliseconds > 1000) {
-      isComplete = false;
-    }
-    // 播放状态变化时，更新
 
     Future<void> send() {
       return VideoHttp.heartBeat(
@@ -1566,18 +1555,21 @@ class PlPlayerController with BlockConfigMixin {
     }
 
     switch (type) {
-      case HeartBeatType.playing:
+      case .playing:
         if (progress - _heartDuration >= 5) {
           _heartDuration = progress;
           return send();
         }
-      case HeartBeatType.status:
+      case .status:
         if (progress - _heartDuration >= 2) {
           _heartDuration = progress;
           return send();
         }
-      case HeartBeatType.completed:
-        if (isComplete) progress = -1;
+      case .completed:
+        if (playerStatus.isCompleted &&
+            (duration.value - position).inMilliseconds <= 1000) {
+          progress = -1;
+        }
         return send();
     }
     return null;

--- a/lib/services/shutdown_timer_service.dart
+++ b/lib/services/shutdown_timer_service.dart
@@ -5,7 +5,6 @@ import 'dart:io';
 import 'package:PiliPlus/models/common/enum_with_label.dart';
 import 'package:PiliPlus/pages/video/introduction/ugc/widgets/menu_row.dart';
 import 'package:PiliPlus/plugin/pl_player/controller.dart';
-import 'package:PiliPlus/plugin/pl_player/models/heart_beat_type.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_status.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:collection/collection.dart';
@@ -107,13 +106,14 @@ class ShutdownTimerService {
   }
 
   void _syncProgressAndExit() {
-    final player = PlPlayerController.instance;
-    if (player != null && player.enableHeart && !player.isLive) {
-      final progress = player.positionSeconds.value;
-      if (progress > 0) {
-        player
-            .makeHeartBeat(progress, type: HeartBeatType.completed, isManual: true)
-            ?.whenComplete(() => exit(0));
+    if (PlPlayerController.instance case final player?) {
+      final res = player.makeHeartBeat(
+        player.positionSeconds.value,
+        type: .completed,
+        isManual: true,
+      );
+      if (res != null) {
+        res.whenComplete(() => exit(0));
         return;
       }
     }

--- a/lib/services/shutdown_timer_service.dart
+++ b/lib/services/shutdown_timer_service.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:PiliPlus/models/common/enum_with_label.dart';
 import 'package:PiliPlus/pages/video/introduction/ugc/widgets/menu_row.dart';
 import 'package:PiliPlus/plugin/pl_player/controller.dart';
+import 'package:PiliPlus/plugin/pl_player/models/heart_beat_type.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_status.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:collection/collection.dart';
@@ -90,7 +91,7 @@ class ShutdownTimerService {
             return;
           }
         }
-        exit(0);
+        _syncProgressAndExit();
     }
   }
 
@@ -101,8 +102,22 @@ class ShutdownTimerService {
         _durationInMinutes = 0;
         SmartDialog.showToast('定时时间已到，已暂停');
       case _ShutdownType.exit:
-        exit(0);
+        _syncProgressAndExit();
     }
+  }
+
+  void _syncProgressAndExit() {
+    final player = PlPlayerController.instance;
+    if (player != null && player.enableHeart && !player.isLive) {
+      final progress = player.positionSeconds.value;
+      if (progress > 0) {
+        player
+            .makeHeartBeat(progress, type: HeartBeatType.completed, isManual: true)
+            ?.whenComplete(() => exit(0));
+        return;
+      }
+    }
+    exit(0);
   }
 
   static (int hour, int minute) _parseMinutes(int minutes) =>


### PR DESCRIPTION
倒计时结束选择"退出APP"时直接调用 exit(0) 终止进程，
跳过了正常退出时的 heartbeat 请求，导致视频进度丢失。
现在退出前先发送 HeartBeatType.completed 请求，完成后再退出。