### PR TITLE
fix(article): fix Opus article body font size too small

### DIFF
--- a/lib/models/dynamics/article_content_model.dart
+++ b/lib/models/dynamics/article_content_model.dart
@@ -134,6 +134,13 @@ class Word {
           );
     fontLevel = json['font_level'];
   }
+
+  // font_level 映射处理：
+  //   "small"   → 13px
+  //   "regular" → 16px（与旧版 HTML 专栏基准一致）
+  //   其余/null → 同 regular
+  double get effectiveFontSize =>
+      fontSize ?? (fontLevel == 'small' ? 13.0 : 16.0);
 }
 
 class Style {

--- a/lib/pages/article/widgets/opus_content.dart
+++ b/lib/pages/article/widgets/opus_content.dart
@@ -151,7 +151,7 @@ class OpusContent extends StatelessWidget {
       style: _getStyle(
         word?.style,
         color ?? defaultColor,
-        word?.fontSize,
+        word?.effectiveFontSize,
       ),
     );
   }


### PR DESCRIPTION
## fix: Opus 新版专栏正文字号偏小

### 问题背景
新版 B 站 Opus 格式专栏将字号字段由 **数值型** (`font_size`) 变更为 **字符串型** (`font_level`)。
* **现状**：客户端尝试读取 `font_size` 结果为 `null`。
* **影响**：字号 fallback 到 Flutter 主题默认值 `bodyMedium` (14px)，视觉效果明显偏小，可见后对比图。

**API 返回示例：**
```json
"word": {
    "font_level": "regular", // 新版字段
    "words": "该报告由众议院科学、空间与技术委员会..."
}
```

### 问题分析
参考 B 站 Web 端 JS 渲染逻辑
<details>
<summary>具体JS 渲染逻辑</summary>

```js
fontSize: function() {
    var e;
    return "small" === this.fontLevel ? "13px" : this.paragraphChildrenStyle ? this.paragraphChildrenStyle.fontSize : "".concat((null === (e = this.customStyle) || void 0 === e ? void 0 : e.font_size) || 17, "px")
},

fontLevel: function() {
    var e, t, n;
    return null !== (e = this.customStyle) && void 0 !== e && e.font_level && "regular" !== (null === (t = this.customStyle) || void 0 === t ? void 0 : t.font_level) ? null === (n = this.customStyle) || void 0 === n ? void 0 : n.font_level : ""
},
```
</details>

其映射关系如下：

| `font_level` | 映射字号 |
| :--- | :--- |
| `"small"` | 13px |
| `"regular"` / 其他 | 17px |

**适配策略**：
考虑到基准字号习惯，本次修复将 `regular` 映射为 **16px**，以保持视觉一致性。

---

### 修改内容
- **模型层** (`Word` Model)：
  - 新增 `effectiveFontSize` getter。
  - 优先级：`font_size` (旧版数值) > `font_level` 映射 (新版字符) > 默认值 16.0。
- **视图层** (`OpusContent`)：
  - 渲染 `TextSpan` 时统一改用 `effectiveFontSize`。

---

### 测试情况
- [x] **新版 Opus 专栏**：正文字号恢复正常（16px）。
- [x] **向下兼容**：旧版 HTML 专栏渲染不受影响。

### 效果对比
| 修复前 | 修复后 |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/4d3973d7-2cbb-4fe5-86a7-041c5f4f2573" width="360" /> | <img src="https://github.com/user-attachments/assets/046d2173-56cc-47dc-bce3-9c5169f7e928" width="360" /> |