### PR TITLE
fix(player): suppress volume indicator during audio duck events

### DIFF
--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -507,8 +507,11 @@ class PlPlayerController with BlockConfigMixin {
     return _instance?.volume.value;
   }
 
-  static Future<void>? setVolumeIfExists(double volumeNew) {
-    return _instance?.setVolume(volumeNew);
+  static Future<void>? setVolumeIfExists(
+    double volumeNew, {
+    bool showIndicator = true,
+  }) {
+    return _instance?.setVolume(volumeNew, showIndicator: showIndicator);
   }
 
   Box video = GStorage.video;
@@ -1254,7 +1257,7 @@ class PlPlayerController with BlockConfigMixin {
   bool volumeInterceptEventStream = false;
 
   static final double maxVolume = PlatformUtils.isDesktop ? 2.0 : 1.0;
-  Future<void> setVolume(double volume) async {
+  Future<void> setVolume(double volume, {bool showIndicator = true}) async {
     if (this.volume.value != volume) {
       this.volume.value = volume;
       try {
@@ -1268,7 +1271,9 @@ class PlPlayerController with BlockConfigMixin {
         if (kDebugMode) debugPrint(err.toString());
       }
     }
-    volumeIndicator.value = true;
+    if (showIndicator) {
+      volumeIndicator.value = true;
+    }
     volumeInterceptEventStream = true;
     volumeTimer?.cancel();
     volumeTimer = Timer(const Duration(milliseconds: 200), () {

--- a/lib/services/audio_session.dart
+++ b/lib/services/audio_session.dart
@@ -28,6 +28,7 @@ class AudioSessionHandler {
           case AudioInterruptionType.duck:
             PlPlayerController.setVolumeIfExists(
               (PlPlayerController.getVolumeIfExists() ?? 0) * 0.5,
+              showIndicator: false,
             );
             // player.setVolume(player.volume.value * 0.5);
             break;
@@ -47,6 +48,7 @@ class AudioSessionHandler {
           case AudioInterruptionType.duck:
             PlPlayerController.setVolumeIfExists(
               (PlPlayerController.getVolumeIfExists() ?? 0) * 2,
+              showIndicator: false,
             );
             // player.setVolume(player.volume.value * 2);
             break;


### PR DESCRIPTION
问题：
在Android上，当在音视频设置中选择输出设备为AAudio时，如果有通知进入（有通知音），会触发Audio的Duck事件，此时屏幕上会在每条通知进入触发duck调整音量的时候都会弹出两次音量控件，减小时一次，放大时一次，而不是其他音频输出设备的静默调整音量，导致观感很差。这个情况在我的HyperOS3（Android16）设备上可以稳定复现，这个Pr尝试修复这个问题


机制猜测：

默认音频输出（OpenSL ES / Auto）：系统在 OS 层面自动压低音量，不发送 AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK 回调给 app
AAudio 输出：系统不做自动压低，而是通知 app 手动处理，触发 interruptionEventStream 的 duck 事件 → app 调用 setVolumeIfExists → setVolume → volumeIndicator.value = true

本次PR的修改：
为 setVolume / setVolumeIfExists 添加 showIndicator 参数（默认 true，向后兼容），duck begin 和 duck end 两处调用均传入 showIndicator: false，使音量静默调整，行为与其他音频输出模式一致。

麻烦大佬看下，感谢